### PR TITLE
Fixed a naming error to reactivate css in the gaming component

### DIFF
--- a/rna/src/App.vue
+++ b/rna/src/App.vue
@@ -9,7 +9,7 @@ import GamingPage from "./components/game/GamingPage.vue";
 </template>
 
 <style>
-#app {
+#game {
   font-family: var(--uni-font);
   color: var(--uni-font-color);
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Just needed to rename the css selector because the were naming issues after the merging of the teaching and gaming component